### PR TITLE
Add error output for the sidecar

### DIFF
--- a/src/run-single-fargate-task.py
+++ b/src/run-single-fargate-task.py
@@ -196,9 +196,9 @@ def prepare_cmd(content, token, region):
         command_content = (
             's3_result="$(aws s3 cp '
             + content
-            + ' /tmp/workspace/)" || {aws stepfunctions send-task-failure --task-token '
+            + ' /tmp/workspace/)" || { aws stepfunctions send-task-failure --task-token '
             + token
-            + '--error "NonZeroExitCode" --cause "$s3_result"; exit 1;} &&'
+            + ' --error "NonZeroExitCode" --cause "$s3_result"; exit 1; } && '
             "unzip /tmp/workspace/"
             + re.findall(r"[^/]*\.zip", content)[0]
             + " -d /tmp/workspace/ && "

--- a/src/run-single-fargate-task.py
+++ b/src/run-single-fargate-task.py
@@ -194,7 +194,11 @@ def prepare_cmd(content, token, region):
         command_content = ""
     else:
         command_content = (
-            "aws s3 cp " + content + " /tmp/workspace/ && "
+            's3_result="$(aws s3 cp '
+            + content
+            + ' /tmp/workspace/)" || {aws stepfunctions send-task-failure --task-token '
+            + token
+            + '--error "NonZeroExitCode" --cause "$s3_result"; exit 1;} &&'
             "unzip /tmp/workspace/"
             + re.findall(r"[^/]*\.zip", content)[0]
             + " -d /tmp/workspace/ && "

--- a/src/run-single-fargate-task.py
+++ b/src/run-single-fargate-task.py
@@ -13,7 +13,9 @@ def verify_inputs(event):
     if event["content"]:
         if not event["content"].lower().endswith(".zip"):
             logger.error("Expected '%s' to be a zip file", event["content"])
-            raise ValueError()
+            raise ValueError(
+                f'Expected \'{event["content"]}\' to be a zip file'
+            )
 
 
 def lambda_handler(event, context):

--- a/src/run-single-fargate-task.py
+++ b/src/run-single-fargate-task.py
@@ -9,10 +9,18 @@ logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
 
+def verify_inputs(event):
+    if event["content"]:
+        if not event["content"].lower().endswith(".zip"):
+            logger.error("Expected '%s' to be a zip file", event["content"])
+            raise ValueError()
+
+
 def lambda_handler(event, context):
     logger.info("event: " + json.dumps(event))
     region = os.environ["AWS_REGION"]
     padded_event = pad_event(event.copy())
+    verify_inputs(padded_event)
     task_definition = create_task_definition(
         "single-use-tasks",
         region,

--- a/src/run-single-fargate-task.py
+++ b/src/run-single-fargate-task.py
@@ -206,7 +206,7 @@ def prepare_cmd(content, token, region):
         command_content = (
             "{ aws s3 cp " + content + " /tmp/workspace/ && "
             "unzip /tmp/workspace/"
-            + re.findall(r"[^/]*\.zip", content)[0]
+            + re.findall(r"[^/]*\.zip", content, flags=re.IGNORECASE)[0]
             + ' -d /tmp/workspace/; echo $? > /tmp/workspace/mount_complete; } 2>&1 | tee /tmp/workspace/sidecar.log && test "$(cat /tmp/workspace/mount_complete)" = 0 || '
             + "{ aws stepfunctions send-task-failure --task-token "
             + f'"{token}"'

--- a/src/run-single-fargate-task.py
+++ b/src/run-single-fargate-task.py
@@ -197,8 +197,8 @@ def prepare_cmd(content, token, region):
             "{ aws s3 cp " + content + " /tmp/workspace/ && "
             "unzip /tmp/workspace/"
             + re.findall(r"[^/]*\.zip", content)[0]
-            + ' -d /tmp/workspace/; echo $? > /tmp/workspace/mount_complete } 2>&1 | tee /tmp/workspace/sidecar.log && test "$(cat /tmp/workspace/mount_complete)" = 0 || '
-            + "{ aws stepfunctions send-task-failure --task-token "
+            + ' -d /tmp/workspace/; echo $? > /tmp/workspace/mount_complete; } 2>&1 | tee /tmp/workspace/sidecar.log && test "$(cat /tmp/workspace/mount_complete)" = 0 || '
+            + "{ aws stepfunctions send-task-failure --task-token "
             + f'"{token}"'
             + ' --error "NonZeroExitCode" --cause "$(cat /tmp/workspace/sidecar.log | tail -c 32768)"; return 1; } && '
         )

--- a/src/run-single-fargate-task.py
+++ b/src/run-single-fargate-task.py
@@ -200,7 +200,7 @@ def prepare_cmd(content, token, region):
             + ' -d /tmp/workspace/; echo $? > /tmp/workspace/mount_complete; } 2>&1 | tee /tmp/workspace/sidecar.log && test "$(cat /tmp/workspace/mount_complete)" = 0 || '
             + "{ aws stepfunctions send-task-failure --task-token "
             + f'"{token}"'
-            + ' --error "NonZeroExitCode" --cause "$(cat /tmp/workspace/sidecar.log | tail -c 32768)"; return 1; } && '
+            + f' --error "NonZeroExitCode" --cause "$(cat /tmp/workspace/sidecar.log && echo && echo "Does the file \'{content}\' exist, and does the container have permissions to access it?" | tail -c 32768)"; return 1; }} && '
         )
     if token == "":
         command_activity_stop = ""


### PR DESCRIPTION
Currently, if `content` is a non-existent file or the container does not have permissions to access it, the Step Function does not fail.

This PR adds error output to the Step Function if something goes wrong during mounting.

Might also be an idea to verify that `image` is valid, but that is a bit more complicated (could be on Docker hub, could be in a restricted ECR repo, ... Would probably need to assume the task execution role directly in the Lambda, and try to fetch the image)