### PR TITLE
Run cmd_to_run in subshell

### DIFF
--- a/src/run-single-fargate-task.py
+++ b/src/run-single-fargate-task.py
@@ -98,7 +98,7 @@ def create_task_definition(
         "sidecar_init \n"
         "rm /tmp/workspace/init_complete \n"
         "cd /tmp/workspace/ \n"
-        "" + cmd_to_run + "\n"
+        "( " + cmd_to_run + " )\n"
         "echo $? > /tmp/workspace/main-complete"
         ") 2>&1 | tee /tmp/workspace/main.log\n"
     )

--- a/src/run-single-fargate-task.py
+++ b/src/run-single-fargate-task.py
@@ -98,7 +98,7 @@ def create_task_definition(
         "sidecar_init \n"
         "rm /tmp/workspace/init_complete \n"
         "cd /tmp/workspace/ \n"
-        "( " + cmd_to_run + " )\n"
+        f"( {cmd_to_run or 'true'} )\n"
         "echo $? > /tmp/workspace/main-complete"
         ") 2>&1 | tee /tmp/workspace/main.log\n"
     )


### PR DESCRIPTION
If someone for whatever reason uses `cmd_to_run = "exit 1"` or `cmd_to_run = "return 1"`, the execution of our code (reporting success/failure back to Step Function) will never run.

This PR fixes this issue by running the user-supplied command in its own subshell.