### PR TITLE
Output ARN of ECS cluster

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -12,3 +12,9 @@ output "task_execution_role_arn" {
   description = "The arn of the ESCTaskExecutionRole created"
   value       = aws_iam_role.task_execution_role.arn
 }
+
+output "ecs_cluster_arn" {
+  description = "The arn of the ECS cluster created"
+  value       = aws_ecs_cluster.ecs_cluster.arn
+}
+


### PR DESCRIPTION
This way we can use this output directly instead of hardcoding the name when passing input to the Lambda, i.e.,:
```
ecs_cluster = module.single_use_fargate_task.ecs_cluster_arn # instead of "${local.name_prefix}-single-tasks"
```