### PR TITLE
Misc improvements

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -12,3 +12,9 @@ output "task_execution_role_arn" {
   description = "The arn of the ESCTaskExecutionRole created"
   value       = aws_iam_role.task_execution_role.arn
 }
+
+output "ecs_cluster_arn" {
+  description = "The arn of the ECS cluster created"
+  value       = aws_ecs_cluster.ecs_cluster.arn
+}
+

--- a/src/run-single-fargate-task.py
+++ b/src/run-single-fargate-task.py
@@ -98,7 +98,7 @@ def create_task_definition(
         "sidecar_init \n"
         "rm /tmp/workspace/init_complete \n"
         "cd /tmp/workspace/ \n"
-        "" + cmd_to_run + "\n"
+        "( " + cmd_to_run + " )\n"
         "echo $? > /tmp/workspace/main-complete"
         ") 2>&1 | tee /tmp/workspace/main.log\n"
     )

--- a/src/run-single-fargate-task.py
+++ b/src/run-single-fargate-task.py
@@ -98,7 +98,7 @@ def create_task_definition(
         "sidecar_init \n"
         "rm /tmp/workspace/init_complete \n"
         "cd /tmp/workspace/ \n"
-        "( " + cmd_to_run + " )\n"
+        f"( {cmd_to_run or 'true'} )\n"
         "echo $? > /tmp/workspace/main-complete"
         ") 2>&1 | tee /tmp/workspace/main.log\n"
     )


### PR DESCRIPTION
- Run `cmd_to_run` in subshell (avoids exiting the script if a user for some reason ends their command with `exit 1` or `return 1`)
- Prefix logs with name of state machine (if passed in)
- Add ARN of ECS cluster as an output