### PR TITLE
Suffix task family with seconds and milliseconds

### DIFF
--- a/src/run-single-fargate-task.py
+++ b/src/run-single-fargate-task.py
@@ -86,7 +86,7 @@ def create_task_definition(
     date_time_obj = datetime.now()
     client = boto3.client("ecs")
     task_family = (
-        f"{task_family_prefix}-{date_time_obj.strftime('%Y%m%d%H%M')}"
+        f"{task_family_prefix}-{date_time_obj.strftime('%Y%m%d%H%M%S%f')[:-3]}"
     )
     shellscript = (
         "cat <<EOF >> /tmp/workspace/error_header.log\n"


### PR DESCRIPTION
This allows us to remove the `Stagger` steps in the Step Function pipeline. The millisecond should practically guarantee that no task family will be created with the same name, thus avoiding the error `Too many concurrent attempts to create a new revision of the specified family`.