### PR TITLE
Add a variable to control Lambda timeout

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -22,6 +22,7 @@ resource "aws_lambda_function" "run_single_fargate_task" {
   runtime          = "python3.7"
   filename         = data.archive_file.lambda_src.output_path
   source_code_hash = filebase64sha256(data.archive_file.lambda_src.output_path)
+  timeout          = var.lambda_timeout
   tags             = var.tags
 }
 
@@ -60,3 +61,4 @@ resource "aws_iam_role_policy" "create_log_group_to_ecs" {
   policy = data.aws_iam_policy_document.create_log_groups_for_ecs.json
   role   = aws_iam_role.task_execution_role.id
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -6,8 +6,14 @@ variable "name_prefix" {
   type        = string
 }
 
+variable "lambda_timeout" {
+  description = "The maximum number of seconds the Lambda is allowed to run."
+  default     = 10
+}
+
 variable "tags" {
   description = "A map of tags (key-value pairs) passed to resources."
   type        = map(string)
   default     = {}
 }
+


### PR DESCRIPTION
Sometimes the Lambda fails because it runs a little bit longer than the default Lambda timeout of 3 seconds. I suggest we up this to at least 10 seconds, and make it controllable through an optional input variable.