### PR TITLE
Remove function keyword from shell scripts

### DIFF
--- a/src/run-single-fargate-task.py
+++ b/src/run-single-fargate-task.py
@@ -111,7 +111,7 @@ def create_task_definition(
         (
         set -eu
         {error_log_command}
-        function sidecar_init() {{
+        sidecar_init() {{
             while [ ! -f /tmp/workspace/init_complete ]; do
                 sleep 1
             done
@@ -244,7 +244,7 @@ def prepare_cmd(content, token, task_name, task_family, region):
     )
     command_head = f"""
         mkdir -p /tmp/workspace/entrypoint
-        function await_main_complete() {{
+        await_main_complete() {{
             while [ ! -f /tmp/workspace/main-complete ]; do
                 sleep 1
             done


### PR DESCRIPTION
Constructing shell functions using the `function` keyword is not POSIX standard. A Docker image with a shell that does not support this (e.g., `gradle:6.2.2-jdk13` uses `dash` shell), will make the main container created by `single-use-fargate-task` fail due to syntax errors.

This PR removes the function keyword, and uses a more portable syntax for shell functions.