### PR TITLE
Add custom CloudWatch metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ Each ZIP file is unzipped to `/tmp/workspace/entrypoint/<mount-name>`.
 
 _(Note: The attribute `mountpoints` and `content` are mutually exclusive. Only 0 or exactly one of them can be used)._
 
+#### metric_namespace (Optional)
+An optional CloudWatch metric namespace to use for publishing CloudWatch custom metrics signaling success or failure of a given Fargate task. Both `metric_namespace` and `metric_dimensions` must be set for metrics to be published.
+
+_(Note: The task role used must have a policy attached allowing it to publish metrics to CloudWatch, i.e., `cloudwatch:PutMetricData`)_
+
+#### metric_dimensions (Optional)
+A map of dimensions to use for the CloudWatch custom metrics published. Both `metric_namespace` and `metric_dimensions` must be set for metrics to be published. (If used in an AWS Step Function state machine, an example value `"metric_dimensions": { "StateMachineName.$": "$$.StateMachine.Name", "StateName.$": "$$.State.Name" }`).
+
+_(Note: The task role used must have a policy attached allowing it to publish metrics to CloudWatch, i.e., `cloudwatch:PutMetricData`)_
+
 #### task_cpu (Optional)
 The task CPU (CPU units or vCPUs) for the Fargate task, defaults to `"256"`. (_Supported values can be found here: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html._)
 
@@ -63,7 +73,7 @@ A list of IDs of security groups associated with the Fargate task. If not specif
 #### task_role_arn (Optional\*)
 The arn of the role the task will assume when running.
 
-_\*Required if the Lambda is used in a Step Functions state machine with the `token` attribute passed in as Lambda input._
+_\*Required if `metric_namespace` and `metric_dimensions` are set, or if the Lambda is used in a Step Functions state machine with the `token` attribute passed in as Lambda input._
 
 #### task_execution_role_arn
 The arn of the role given to Fargate to run tasks - this is typically a role with the managed `AmazonECSTaskExecutionRolePolicy` policy attached.

--- a/README.md
+++ b/README.md
@@ -46,12 +46,12 @@ Each ZIP file is unzipped to `/tmp/workspace/entrypoint/<mount-name>`.
 _(Note: The attribute `mountpoints` and `content` are mutually exclusive. Only 0 or exactly one of them can be used)._
 
 #### metric_namespace (Optional)
-An optional CloudWatch metric namespace to use for publishing CloudWatch custom metrics signaling success or failure of a given Fargate task. Both `metric_namespace` and `metric_dimensions` must be set for metrics to be published.
+An optional CloudWatch metric namespace to use for publishing CloudWatch custom metrics signaling success or failure of a given Fargate task.
 
 _(Note: The task role used must have a policy attached allowing it to publish metrics to CloudWatch, i.e., `cloudwatch:PutMetricData`)_
 
 #### metric_dimensions (Optional)
-A map of dimensions to use for the CloudWatch custom metrics published. Both `metric_namespace` and `metric_dimensions` must be set for metrics to be published. (If used in an AWS Step Function state machine, an example value `"metric_dimensions": { "StateMachineName.$": "$$.StateMachine.Name", "StateName.$": "$$.State.Name" }`).
+A map of dimensions to use for the CloudWatch custom metrics published. Requires `metric_namespace` to be set. (If used in an AWS Step Function state machine, an example value `"metric_dimensions": { "StateMachineName.$": "$$.StateMachine.Name", "StateName.$": "$$.State.Name" }`).
 
 _(Note: The task role used must have a policy attached allowing it to publish metrics to CloudWatch, i.e., `cloudwatch:PutMetricData`)_
 
@@ -73,7 +73,7 @@ A list of IDs of security groups associated with the Fargate task. If not specif
 #### task_role_arn (Optional\*)
 The arn of the role the task will assume when running.
 
-_\*Required if `metric_namespace` and `metric_dimensions` are set, or if the Lambda is used in a Step Functions state machine with the `token` attribute passed in as Lambda input._
+_\*Required if `metric_namespace` is set, or if the Lambda is used in a Step Functions state machine with the `token` attribute passed in as Lambda input._
 
 #### task_execution_role_arn
 The arn of the role given to Fargate to run tasks - this is typically a role with the managed `AmazonECSTaskExecutionRolePolicy` policy attached.

--- a/src/run-single-fargate-task.py
+++ b/src/run-single-fargate-task.py
@@ -101,6 +101,8 @@ def lambda_handler(event, context):
         padded_event["assign_public_ip"],
         padded_event["security_groups"],
         padded_event["send_error_logs_to_stepfunctions"],
+        padded_event["metric_namespace"],
+        padded_event["metric_dimensions"],
     )
     clean_up(task_definition)
 
@@ -120,6 +122,8 @@ def set_defaults(event):
         "token": "",
         "log_stream_prefix": "task",
         "credentials_secret_arn": "",
+        "metric_namespace": "",
+        "metric_dimensions": {},
         "send_error_logs_to_stepfunctions": True,
     }
 
@@ -269,6 +273,8 @@ def run_task(
     assign_public_ip,
     security_groups,
     send_error_logs_to_stepfunctions,
+    metric_namespace,
+    metric_dimensions,
     sidecar_log_group_name=SIDECAR_LOG_GROUP_NAME,
 ):
     """Start the Fargate task and return the ARN of the task"""
@@ -280,6 +286,8 @@ def run_task(
         sidecar_log_group_name,
         task_definition["family"],
         region,
+        metric_namespace,
+        metric_dimensions,
         send_error_logs_to_stepfunctions=send_error_logs_to_stepfunctions,
     )
     logger.info("sidecar command str: " + json.dumps(command_str))
@@ -337,6 +345,8 @@ def prepare_sidecar_cmd(
     log_group_name,
     log_stream_prefix,
     region,
+    metric_namespace,
+    metric_dimensions,
     send_error_logs_to_stepfunctions=True,
 ):
     """Return the shell script command to run inside the sidecar container"""
@@ -366,9 +376,8 @@ def prepare_sidecar_cmd(
             unzip {SIDECAR_CONTAINER_FOLDER}/{zip_file} -d {destination}
         """
     command_sidecar_failure = ""
-    if token == "":
-        command_activity_stop = ""
-    else:
+    command_activity_stop = ""
+    if token:
         # The `--cause` parameter for `send-task-failure` has a limit of 32768 characters
         command_activity_stop = f"""
             result="$(cat {MAIN_CONTAINER_FOLDER}/complete)"
@@ -387,6 +396,26 @@ def prepare_sidecar_cmd(
                     echo "Failed to report sidecar failure"
                 done
             fi
+        """
+    if metric_namespace and metric_dimensions:
+        stringified_dimensions = ",".join(
+            [key + "=" + val for key, val in metric_dimensions.items()]
+        )
+        command_activity_stop += f"""
+        result="$(cat {MAIN_CONTAINER_FOLDER}/complete)"
+        if [ "$result" -eq 0 ]; then
+            metric_name="TaskSuccess"
+        else
+            metric_name="TaskFailure"
+        fi
+        echo "Publishing custom metric to CloudWatch"
+        aws cloudwatch put-metric-data \\
+            --metric-name "$metric_name" \\
+            --namespace "{metric_namespace}" \\
+            --dimensions "{stringified_dimensions}" \\
+            --storage-resolution 1 \\
+            --value 1 \\
+            --unit Count
         """
 
     command_init_complete = f"touch {SIDECAR_CONTAINER_FOLDER}/init-complete"

--- a/src/run-single-fargate-task.py
+++ b/src/run-single-fargate-task.py
@@ -398,9 +398,14 @@ def prepare_sidecar_cmd(
                 done
             fi
         """
-    if metric_namespace and metric_dimensions:
+    if metric_namespace:
         stringified_dimensions = ",".join(
             [key + "=" + val for key, val in metric_dimensions.items()]
+        )
+        dimensions_arg = (
+            f'--dimensions "{stringified_dimensions}"'
+            if stringified_dimensions
+            else ""
         )
         command_activity_stop += f"""
         result="$(cat {MAIN_CONTAINER_FOLDER}/complete)"
@@ -413,7 +418,7 @@ def prepare_sidecar_cmd(
         aws cloudwatch put-metric-data \\
             --metric-name "$metric_name" \\
             --namespace "{metric_namespace}" \\
-            --dimensions "{stringified_dimensions}" \\
+            {dimensions_arg} \\
             --storage-resolution 1 \\
             --value 1 \\
             --unit Count

--- a/src/run-single-fargate-task.py
+++ b/src/run-single-fargate-task.py
@@ -176,8 +176,9 @@ def create_task_definition(
         cd {entrypoint}
         ( set +u; {cmd_to_run or 'true'} )
         )
-        echo $? > {MAIN_CONTAINER_FOLDER}/complete
+        echo "$?" > {MAIN_CONTAINER_FOLDER}/complete
         }} 2>&1 | tee {MAIN_CONTAINER_FOLDER}/main.log
+        exit "$(cat {MAIN_CONTAINER_FOLDER}/complete)"
     """
     # Strip leading whitespace to avoid syntax errors due to heredoc indentation
     shellscript = "\n".join(


### PR DESCRIPTION
- Add optional publication of CloudWatch custom metric for monitoring success or failure of a given task in (near-)realtime

The metric dimensions are fully customizable and optional. They can be used to e.g., correlate a given metric with a given state in a given state machine, and set up CloudWatch alarms for monitoring these metrics.

## Breaking changes
- None. (The functionality is opt-in, but requires the task role to be extended with permissions for CloudWatch.)